### PR TITLE
Fix support for module info with anonymous functions.

### DIFF
--- a/plugins/extensions/System.php
+++ b/plugins/extensions/System.php
@@ -723,7 +723,8 @@ class System_commands extends extension {
 			if ($from !== 'Botdom') return;
 
 			$download = file_get_contents($downloadlink);
-			$filename = explode('/', $downloadlink)[4];
+			$splodey = explode('/', $downloadlink);
+			$filename = $splodey[4];
 
 			$file = fopen($filename, 'w+');
 			fwrite($file, $download);


### PR DESCRIPTION
Fixes an issue with `!module info` when the module had an event bound with an anonymous function.
