### PR TITLE
Typo, Notice

### DIFF
--- a/core/Core_class.php
+++ b/core/Core_class.php
@@ -126,7 +126,8 @@ class Bot {
 		$config = include './storage/config.cf';
 		$this->username = $config['info']['username'];
 		$this->owner = $config['info']['owner'];
-		$this->trigger = mb_convert_encoding($config['info']['trigger'], 'HTML-ENTITIES', 'UTF-8');;
+		// Note: This may require the PHP extension 'mbstring', someone should look into this on Windows.
+		$this->trigger = mb_convert_encoding($config['info']['trigger'], 'HTML-ENTITIES', 'UTF-8');
 		$this->aboutStr = $config['about'];
 		$this->autojoin = $config['autojoin'];
 		if(isset($config['cookie']))


### PR DESCRIPTION
Typo, added an extra semicolon by accident. Also, notice.
